### PR TITLE
Mainly corrected typos (removed hyphens from proposal types)

### DIFF
--- a/cps/CP0/CP0.md
+++ b/cps/CP0/CP0.md
@@ -25,7 +25,7 @@ In our proposal to become a core group in the Centrifuge DAO, and get a mandate 
 - All proposals must follow their respective Governance process
 - A CP must be as clear and easy to understand as possible. Any member of the community without special knowledge should be able to understand the meaning and purpose of the proposal, even if not all details
 - A CP must be thorough. Relevant information or categories must not be left undefined
-- The proposer must select the relevant type CP (e.g. CP-1, CP-2 etc.) and provide the information mandated by their templates
+- The proposer must select the relevant type CP (e.g. CP1, CP2 etc.) and provide the information mandated by their templates
 - CPs must use the baseline timing of their Governance process but can use extensions if needed. If you want to use an extension make it clear in the RFC itself and outline why you think an extension is needed
 - Using the principles, process, and CP framework, anyone can create a CP at any time
 
@@ -46,7 +46,7 @@ After a proposal has been submitted, a pull request number (XXXX) will automatic
 
 ### Snapshot voting
 
-Snapshot voting has replaced our Forum polls and is always the next step in the off-chain governance after an RFC (except for CP-2, CP-3 and CP-3.1, that do not require it). Once there has been adequate discussion of a proposal (after a minimum of 7 days) - and the proposal has been submitted to the PR - a snapshot vote must be created on [OpenSquare](https://voting.opensquare.io/space/centrifuge).
+Snapshot voting has replaced our Forum polls and is always the next step in the off-chain governance after an RFC (except for CP2, CP3 and CP3.1, that do not require it). Once there has been adequate discussion of a proposal (after a minimum of 7 days) - and the proposal has been submitted to the PR - a snapshot vote must be created on [OpenSquare](https://voting.opensquare.io/space/centrifuge).
 
 If a proposal does not require an on-chain vote, the snapshot vote will be binding (i.e. if the snapshot vote passes, the proposal passes).
 
@@ -96,14 +96,15 @@ We have defined the following proposal types (CPs) and assigned them each with a
 
 |CP #|Proposal type|Short description|
 | --- | --- | --- |
-|[CP-1](../CP1/CP1.md)|Request for Mandate with Funding|Seeking mandate as a group/individual within the Centrifuge DAO to enact a project/work stream|
-|[CP-1.1](../CP1/CP1.md)|Request for Mandate without Funding|Same as CP-1, just without initial funding|
-|[CP-1.2](../CP1/CP1.md)|Removal of Mandate|Removal of a group’s mandate to enact a project/work stream (CP-1)|
-|[CP-2](../CP2/CP2.md)|Request for Funding|Asking for funding from the Treasury|
-|[CP-3](../CP3/CP3.md)|Runtime Upgrades|Proposals for Runtime Upgrades|
-|[CP-3.1](../CP3/CP3.md)|Emergency Proposals|Emergency proposals in case of hacks, exploits, attacks, or network halt|
-|[CP-4](../CP4/CP4.md)|General Improvements|Any proposal type, that does not fit under any of the other CPs|
-|[CP-5](../CP5/CP5.md)|Centrifuge Pool Onboarding Proposal (POP)|Onboarding new pools on Centrifuge Chain|
+|[CP1](../CP1/CP1.md)|Request for Mandate with Funding|Seeking mandate as a group/individual within the Centrifuge DAO to enact a project/work stream|
+|[CP1.1](../CP1/CP1.md)|Request for Mandate without Funding|Same as CP-1, just without initial funding|
+|[CP1.2](../CP1/CP1.md)|Removal of Mandate|Removal of a group’s mandate to enact a project/work stream (CP-1)|
+|[CP2](../CP2/CP2.md)|Request for Funding|Asking for funding from the Treasury|
+|[CP3](../CP3/CP3.md)|Runtime Upgrades|Proposals for Runtime Upgrades|
+|[CP3.1](../CP3/CP3.md)|Emergency Proposals|Emergency proposals in case of hacks, exploits, attacks, or network halt|
+|[CP4](../CP4/CP4.md)|General Improvements|Any proposal type, that does not fit under any of the other CPs|
+|[CP5](../CP5/CP5.md)|Centrifuge Pool Onboarding Proposal (POP)|Onboarding new pools on Centrifuge Chain|
+|[CP32](../CP32.md)|Roadmap Proposals|Create a Roadmap Proposal to replace the previous one|
 
 In general, the Governance process can be divided into two parts; *off-chain* and *on-chain Governance*.
 

--- a/cps/CP1/CP1.md
+++ b/cps/CP1/CP1.md
@@ -7,13 +7,13 @@ date passed: 2022-11-12
 status: passed
 ---
 
-# CP-1 (MRF): Request for Mandate with Funding
+# CP1 (MRF): Request for Mandate with Funding
 
 A mandate can be interpreted as an entity (group or individual) being given the authority by the DAO to pursue the stated objectives. The entity takes on the responsibility of fulfilling the mandate and accepts accountability to the DAO over this. 
 
 Work can be initiated and brought to the DAO without a mandate, but no individual or group may claim to be working on behalf of the DAO without a mandate. 
 
-A mandate indicates long term commitment (i.e. not a one time service, like creating a video for a specific purpose) and hence on-going funding. The maximum funding period is 6 months. This means that every 6 months, the group or individual would need to re-apply for funding by submitting a CP-2.
+A mandate indicates long term commitment (i.e. not a one time service, like creating a video for a specific purpose) and hence on-going funding. The maximum funding period is 6 months. This means that every 6 months, the group or individual would need to re-apply for funding by submitting a CP2.
 
 ### GOVERNANCE PROCESS
 
@@ -39,7 +39,7 @@ Tags: cp-1, month, year
 ```
 #### Body of the RFC must contain:
 ```
-Proposal type: CP-1
+Proposal type: CP1
 Author(s): Forum handle(s) of author(s)
 Member(s): Forum handle(s) of member(s)
 Date proposed: yyyy-mm-dd
@@ -76,22 +76,22 @@ Delivery and Reporting
 - A timeline of when the objective(s) will be delivered and how this will be reported
 ```
 
-# CP-1.1 (MR) Mandate Request without Funding
+# CP1.1 (MR) Mandate Request without Funding
 
-Same as CP-1, just without funding (i.e. no step 5 and Budget does not need to be specified in the RFC).
+Same as CP1, just without funding (i.e. no step 5 and Budget does not need to be specified in the RFC).
 
-A group can make a proposal for seeking a mandate for a specific project/work stream and then afterwards apply for funding using a CP-2.
+A group can make a proposal for seeking a mandate for a specific project/work stream and then afterwards apply for funding using a CP2.
 
-# CP-1.2 (REM) Removal of Mandate
+# CP1.2 (REM) Removal of Mandate
 
-In order to revoke a mandate from a group, or individual in a group, a CP-1.2 proposal has to be created.
+In order to revoke a mandate from a group, or individual in a group, a CP1.2 proposal has to be created.
 
 This can happen in two ways:
 
 1) *The group/individual itself no longer wants its mandate within the DAO*
 2) *The Community/DAO wants to revoke the mandate of a group/individual in a group*
 
-The group itself has autonomy to include and remove members, but in the case that someone breaks the Code of Conduct (forthcoming), the DAO can propose to remove a group member from the group. 
+The group itself has autonomy to include and remove members, but in the case that someone breaks the [Code of Conduct](https://github.com/centrifuge/cps/blob/main/cps/CP29/Appendices/FD4-CoC.md), the DAO can propose to remove a group member from the group. 
 
 ### GOVERNANCE PROCESS
 
@@ -99,7 +99,7 @@ The group itself has autonomy to include and remove members, but in the case tha
 
 |STEP|DESCRIPTION|DURATION|
 | --- | --- | :---: |
-|1|Create a Proposal post (still a CP-1.2) on the [Forum](https://gov.centrifuge.io/c/cfg-governance/chain-governance/18) with an explanation of the revocation of the mandate|-|
+|1|Create a Proposal post (still a CP1.2) on the [Forum](https://gov.centrifuge.io/c/cfg-governance/chain-governance/18) with an explanation of the revocation of the mandate|-|
 |2|Submit proposal to the [Centrifuge Proposals Repository](https://github.com/centrifuge/cps) (on Github)|-|
 
 Once the announcement has been made, and the proposal has been submitted to the Centrifuge Proposals Repository, the group has automatically been revoked of its mandate. 
@@ -123,9 +123,9 @@ Tags: cp-1.2, month, year
 ```
 #### Body of the RFC must contain:
 ```
-Proposal type: CP-1.2
+Proposal type: CP1.2
 Author(s): Forum handle(s) of author(s)
-Related to: link to the CP-1 or CP-1.1 where mandate was obtained
+Related to: link to the CP1 or CP1.1 where mandate was obtained
 Date proposed: yyyy-mm-dd
 
 Short Summary 

--- a/cps/CP2/CP2.md
+++ b/cps/CP2/CP2.md
@@ -7,12 +7,12 @@ date passed: 2022-11-12
 status: passed
 ---
 
-# CP-2 (RF): Request for Funding
+# CP2 (RF): Request for Funding
 
-Any entity (group or individual) who seeks funding from the Treasury, would need to create a CP-2 proposal. There can be different scenarios for an entity applying for funding:
+Any entity (group or individual) who seeks funding from the Treasury, would need to create a CP2 proposal. There can be different scenarios for an entity applying for funding:
 
-- The entity already created a CP-1 (that passed) and received funding and wants to re-apply
-- The entity already created a CP-1.1 (that passed) and wants to apply for funding
+- The entity already created a CP1 (that passed) and received funding and wants to re-apply
+- The entity already created a CP1.1 (that passed) and wants to apply for funding
 - The entity doesn’t have a mandate but wants to apply for funding for a one time service
 
 The Treasury is administered by the Council so only the Council will vote on the proposal - token holders will not vote on it. 
@@ -40,10 +40,10 @@ Tags: cp-2, month, year
 ```
 #### Body of the RFC must contain:
 ```
-Proposal type: CP-2
+Proposal type: CP2
 Author(s): Forum handle(s) of author(s)
 Beneficiary: Forum handle(s) of beneficiary
-Mandate: link to CP-1 or CP-1.1 (only if mandate already obtained and relevant)
+Mandate: link to CP1 or CP1.1 (only if mandate already obtained and relevant)
 Wallet: wallet address where fund should be transferred
 Date proposed: yyyy-mm-dd
 

--- a/cps/CP21.md
+++ b/cps/CP21.md
@@ -3,7 +3,7 @@ cp: 21
 title: Updating Tinlake Rewards Allocation
 authors: Governance and Coordination Group (ImdioR, Rhano)
 contributors:
-proposal-type: CP-4 technical
+proposal-type: CP4 technical
 date-proposed: 2022-12-16
 date-ended: 2023-01-03
 status: passed

--- a/cps/CP23.md
+++ b/cps/CP23.md
@@ -3,7 +3,7 @@ cp: 23
 title: Renewal RWA Market rewards proposal 
 authors: Governance and Coordination Group (ImdioR, Rhano)
 contributors:
-proposal-type: CP-4 technical
+proposal-type: CP4 technical
 date-proposed: 2022-12-08
 date-ended: 2022-12-28
 status: passed

--- a/cps/CP24.md
+++ b/cps/CP24.md
@@ -3,7 +3,7 @@ cp: 26
 title: Runtime Upgrade 1016
 authors: k/f
 contributors: 
-proposal-type: CP-3.1
+proposal-type: CP3.1
 date-proposed: 2023-01-19
 date-ended: 2023-01-25
 status: passed

--- a/cps/CP28.md
+++ b/cps/CP28.md
@@ -3,7 +3,7 @@ cp: 28
 title: Centrifuge Protocol Fees 
 authors: Governance and Coordination Group (ImdioR, Rhano)
 contributors:
-proposal-type: CP-4 technical
+proposal-type: CP4 technical
 date-proposed: 2023-01-19
 date-ended: 2023-02-15
 status: passed

--- a/cps/CP29/CP29.md
+++ b/cps/CP29/CP29.md
@@ -3,7 +3,7 @@ cp: 29
 title: Founding Documents of the Centrifuge DAO
 authors: Governance and Coordination Group (ImdioR, Orhan)
 contributors: Kate, Lucas, Asad & David
-proposal-type: CP-4 non-technical proposal
+proposal-type: CP4 non-technical proposal
 date-proposed: 2023-01-27
 date-ended: 2023-03-02
 status: passed

--- a/cps/CP3/CP3.md
+++ b/cps/CP3/CP3.md
@@ -7,11 +7,11 @@ date passed: 2022-11-12
 status: passed
 ---
 
-# CP-3 (RU) Runtime Upgrades 
+# CP3 (RU) Runtime Upgrades 
 
-CP-3 is used to propose Runtime Upgrades. Runtime Upgrades allow developers and community members to change the logic of the chain, or parameter for pallets, without the need for a hard fork.
+CP3 is used to propose Runtime Upgrades. Runtime Upgrades allow developers and community members to change the logic of the chain, or parameter for pallets, without the need for a hard fork.
 
-Runtime Upgrades may contain previously passed CP-4s (General Improvements) - this will be specified in the Proposal post.
+Runtime Upgrades may contain previously passed CP4s (General Improvements) - this will be specified in the Proposal post.
 
 ### GOVERNANCE PROCESS
 
@@ -35,7 +35,7 @@ Tags: CP-3, month, year
 ```
 #### Body of the post must contain:
 ```
-Proposal type: CP-3
+Proposal type: CP3
 Author(s): Forum handle(s) of author(s)
 Contributor(s): Forum handle(s) of contributor(s)
 Proposal on Proposal Repository (Github): INSERT LINK
@@ -43,7 +43,7 @@ Date proposed: yyyy-mm-dd
 
 List of content of this Runtime Upgrade
 - Added functionalities, changed parameters etc.
-- If CP-4s are included, link to their Proposal post
+- If CP4s are included, link to their Proposal post
 
 Detailed description of each content 
 - Describe the different content above in details
@@ -53,9 +53,9 @@ Governance process for this proposal
 - Duration of referendum vote
 ```
 
-#  CP-3.1 (EP) Emergency Proposals
+#  CP3.1 (EP) Emergency Proposals
 
-CP-3.1 is used to propose emergency proposals in order to avoid or prevent hacks, exploits, attacks, or network halts.
+CP3.1 is used to propose emergency proposals in order to avoid or prevent hacks, exploits, attacks, or network halts.
 
 In order to protect the protocol, some actions or changes may take place without prior notice (Council motions + referenda).
 

--- a/cps/CP32.md
+++ b/cps/CP32.md
@@ -3,7 +3,7 @@ cp: 32
 title: Roadmap Process & Protocol Engineering Group Mandate 
 authors: Jeroen
 contributors: 
-proposal-type: CP-1.1 (Mandate Request without Funding)
+proposal-type: CP1.1 (Mandate Request without Funding)
 date-proposed: 2023-02-07
 date-ended: 2023-03-02
 status: passed
@@ -15,7 +15,7 @@ Proposal for the creation of a new Protocol Engineering Group, composed of core 
 ## High level objective 
 Mandate a group in the DAO with two key objectives:
 * Provide feedback on technical feasibility of improvement proposals in the community and propose technical implementations;
-* Collect all improvement proposals that were discussed, voted on and approved by CFG token holders and propose a roadmap for CFG token holders to vote on and create a new proposal type (CP-6 Roadmap Proposals) to be added to the Governance Process.
+* Collect all improvement proposals that were discussed, voted on and approved by CFG token holders and propose a roadmap for CFG token holders to vote on and create a new proposal type (CP32 Roadmap Proposals) to be added to the Governance Process.
 
 ## Background 
 As the Centrifuge DAO furthers its journey to decentralization, key new features being voted in to be implemented to the protocol are being discussed in the community, and are being proposed by an increasing number of parties.
@@ -58,11 +58,11 @@ The PE Group is responsible for updating and proposing a roadmap following this 
 
 **Roadmap Proposal Template**
 ```
-Proposal type: CP-XXX
+Proposal type: CP32
 Author(s): Forum handle(s) of author(s)
 Contributor(s): Forum handle(s) of contributor(s)
 Date proposed: yyyy-mm-dd
-Replaces Previous Roadmap: CP-XXX
+Replaces Previous Roadmap: CPXXX
 
 Short Summary
 - One sentence summary of proposal

--- a/cps/CP34.md
+++ b/cps/CP34.md
@@ -3,7 +3,7 @@ cp: 34
 title: Open HRMP channels between Centrifuge and HydraDX 
 authors: jgreen
 contributors:
-proposal-type: CP-4 technical
+proposal-type: CP4 technical
 date-proposed: 2023-02-02
 date-ended: 
 status: polling 

--- a/cps/CP4/CP4.md
+++ b/cps/CP4/CP4.md
@@ -7,17 +7,17 @@ date passed: 2022-11-12
 status: passed
 ---
 
-# CP-4 (GI): General Improvements
+# CP4 (GI): General Improvements
 
-This CP is used for proposals that don’t fit under any of the types. In other words, if it is not a CP-1, CP-2, CP-3 or CP-5 (or any of their derivatives), it is a CP-4. 
+This CP is used for proposals that don’t fit under any of the types. In other words, if it is not a CP1, CP2, CP3 or CP5 (or any of their derivatives), it is a CP4. 
 
-A CP-4 can therefore be a wide range of proposal types, to improve the protocol or expand the ecosystem, and that require input from the Community. A CP-4 can roughly be divided into two categories; technical and non-technical.
+A CP4 can therefore be a wide range of proposal types, to improve the protocol or expand the ecosystem, and that require input from the Community. A CP4 can roughly be divided into two categories; technical and non-technical.
 
-### Technical CP-4
+### Technical CP4
 
-These can be proposals for the roadmap and technical features and functionality of the Centrifuge protocol, such as adjustment of fees, burning of tokens, liquidity pairing with another protocol, opening HRMP channels between other parachains etc. If passed, these proposals will typically be part of a Runtime Upgrade (CP-3) afterwards, but not always.
+These can be proposals for the roadmap and technical features and functionality of the Centrifuge protocol, such as adjustment of fees, burning of tokens, liquidity pairing with another protocol, opening HRMP channels between other parachains etc. If passed, these proposals will typically be part of a Runtime Upgrade (CP3) afterwards, but not always.
 
-### Non-technical CP-4
+### Non-technical CP4
 These are proposals that do not require a change on the blockchain, and hence do not require an on-chain vote. This could be co-marketing partnerships, changes to the Governance process, incentivising users with NFTs for participation in Governance, creating events etc.
 
 ### GOVERNANCE PROCESS
@@ -31,7 +31,7 @@ These are proposals that do not require a change on the blockchain, and hence do
 
 For **non-technical proposals**, the process ends here and if the snapshot vote passes (majority of CFG votes in favor of the proposal), the proposal passes. 
 
-For **technical proposals**, if it is a standalone proposal - i.e. not part of a Runtime Upgrade (CP-3) - there will be two more steps. 
+For **technical proposals**, if it is a standalone proposal - i.e. not part of a Runtime Upgrade (CP3) - there will be two more steps. 
 
 |STEP|DESCRIPTION|DURATION|
 | --- | --- | :---: |
@@ -47,7 +47,7 @@ Tags: cp-4, month, year
 ```
 #### Body of the RFC must contain:
 ```
-Proposal type: CP-4
+Proposal type: CP4
 Author(s): Forum handle(s) of author(s)
 Contributor(s): Forum handle(s) of contributor(s)
 Technical/non-technical proposal: specify type

--- a/cps/CP5/CP5.md
+++ b/cps/CP5/CP5.md
@@ -3,7 +3,7 @@ cp: 5
 title: POP (Pool Onboarding Proposal)
 authors: Colin
 contributors: Jay
-proposal-type: CP-4 non-technical
+proposal-type: CP4 non-technical
 date-proposed: 2022-12-14
 date-ended: 2023-03-02
 status: passed
@@ -13,7 +13,7 @@ status: passed
 Proposal for an improved version of the POP from the [current POP that exists today](https://gov.centrifuge.io/t/introducing-the-pool-onboarding-proposal-pop/3846).
 
 ## High Level Objective
-To simplify the POP process for RWAs onboarding through the Centrifuge protocol and to increase the Community engagement and participation in the process. If this proposal is to pass in the future, it will be added as CP-5 (POP) to the governance process.
+To simplify the POP process for RWAs onboarding through the Centrifuge protocol and to increase the Community engagement and participation in the process. If this proposal is to pass in the future, it will be added as CP5 (POP) to the governance process.
 
 ## Background
 The POP has been active for over 6 months. In that time, we’ve seen 12 POPs submitted, a number of Introductions, a couple of Pool Parties, and the discussion and engagement around RWAs continues to rise across the Forum.

--- a/cps/CP6.md
+++ b/cps/CP6.md
@@ -3,7 +3,7 @@ cp: 6
 title: Add a block reward and improve Collator cycle
 authors: Governance and Coordination Group (ImdioR, Orhan)
 advisors: Cassidy, Miguel
-proposal-type: CP-4
+proposal-type: CP4 technical
 date-proposed: 2022-11-16
 date-ended: 2022-12-17
 status: passed


### PR DESCRIPTION
All changes made:

- Removed hyphen from all proposal types (e.g. CP-1 -> CP1 etc), from both descriptions and templates
- CP32 (Roadmap Proposals) added as a proposal type to our Governance Process ([CP0](https://github.com/centrifuge/cps/blob/main/cps/CP0/CP0.md) file)
- Changed CP-6 (incorrect) to CP32 in the [proposal for the PEG mandate](https://github.com/centrifuge/cps/blob/main/cps/CP32.md)
- Added hyperlink to CoC in [CP1.2 ](https://github.com/centrifuge/cps/blob/main/cps/CP1/CP1.md)(Removal of Mandate)