### PR TITLE
fix: broken link for proposed cps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,6 @@ This repository contains all submitted Centriuge Proposals. The gensis proposal 
 ## Proposed CPs
 |CP | Short title |
 |---|-------------|
-|[CP39]((./cps/CP39.md)) |EVM compatibility on the Centrifuge Chain and Centrifuge App |
-|[CP40]((./cps/CP40.md)) |Updating Tinlake Rewards Allocation 2023-03 |
+|[CP39](./cps/CP39.md) | EVM compatibility on the Centrifuge Chain and Centrifuge App |
+|[CP40](./cps/CP40.md) | Updating Tinlake Rewards Allocation 2023-03 |
 


### PR DESCRIPTION
Fixes two broken links for CPs in `proposed` state: CP39 and CP40.