### PR TITLE
fix: typo on filename cp45

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,5 @@ This repository contains all submitted Centriuge Proposals. The gensis proposal 
 |---|-------------|
 |[CP39](./cps/CP39.md) | EVM compatibility on the Centrifuge Chain and Centrifuge App |
 |[CP40](./cps/CP40.md) | Updating Tinlake Rewards Allocation 2023-03 |
-|[CP45](./cps/CP45.m)  | Runtime Upgrade 1018 |
+|[CP45](./cps/CP45.md)  | Runtime Upgrade 1018 |
 


### PR DESCRIPTION
Fixes typo issue on CP45 link in Readme which accidently slipped through in #44 