### PR TITLE
Adding + updating governance links in CPs

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ This repository contains all submitted Centriuge Proposals. The genesis proposal
 | [CP83](./cps/CP83.md)  | Updating CP28 Centrifuge Protocol Fees    |
 | [CP84](./cps/CP84.md)  | Unclaimed Polkadot Rewards    |
 | [CP86](./cps/CP86.md)  | OpenGov Technical Committee Mandate Request    |
+| [CP87](./cps/CP87.md)  | Roadmap Proposal 1    |
 
 ## Rejected CPs
 |CP | Short title |
@@ -54,7 +55,7 @@ This repository contains all submitted Centriuge Proposals. The genesis proposal
 ## Proposed CPs
 |CP | Short title |
 |---|-------------|
-| [CP87](./cps/CP87.md)  | Roadmap Proposal 1    |
+
 
 
 

--- a/cps/CP21.md
+++ b/cps/CP21.md
@@ -50,4 +50,6 @@ Governance and Coordination Group (ImdioR, Rhano)
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-updating-tinlake-rewards-allocation-2022-12/4893
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmWSgMxq436g5EWs6RAnx9pkYcwY8dBHMGHsqYNGWJwkev
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/116
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/27

--- a/cps/CP23.md
+++ b/cps/CP23.md
@@ -49,4 +49,7 @@ Minting the 200,000 CFG tokens as rewards will ensure that lenders on RWA Market
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-renewal-rwa-market-rewards-proposal-2022-12/4855
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmaXhVQVWyrY6vjHha1wMQRrPhVv19yKo7NmEJRVjmxANo
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/112
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/51
+

--- a/cps/CP26.md
+++ b/cps/CP26.md
@@ -24,3 +24,7 @@ status: passed
 ## Governance process for this proposal
 1. Council Motion + fast track
 2. Referendum vote open for 36,000 blocks (~5 days)
+
+Link to onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/53
+
+

--- a/cps/CP26.md
+++ b/cps/CP26.md
@@ -25,6 +25,6 @@ status: passed
 1. Council Motion + fast track
 2. Referendum vote open for 36,000 blocks (~5 days)
 
-Link to onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/53
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/53
 
 

--- a/cps/CP29/CP29.md
+++ b/cps/CP29/CP29.md
@@ -53,4 +53,5 @@ One of the goals of this RFC is to clearly define the mission of Centrifuge.
 
 Link to RFC on the Forum: https://gov.centrifuge.io/t/rfc-founding-documents-of-the-centrifuge-dao/5073
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/Qma8owSqBDisMHYucvE6RU4k9UNAPjYXEaoRgsuG8A2jkT
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/122
+

--- a/cps/CP32.md
+++ b/cps/CP32.md
@@ -98,4 +98,4 @@ The Protocol Engineering Group aims to start its work immediately if the CP is a
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-roadmap-process-protocol-engineering-group-mandate/5136
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmPg4rTU1cpQxjGAvJ31CXRaYeuQW3FH4Q5p8sJXsSaHwE
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/120

--- a/cps/CP34.md
+++ b/cps/CP34.md
@@ -64,4 +64,4 @@ Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-open-hrmp-channels
 
 Link to the Opensquare Snapshot: https://voting.opensquare.io/p/124
 
-Link to onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/58
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/58

--- a/cps/CP34.md
+++ b/cps/CP34.md
@@ -62,4 +62,6 @@ https://docs.hydradx.io/
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-open-hrmp-channels-between-centrifuge-and-hydradx/5104
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmPRYAjaKxEsEP26xMxPytZwt1fXWF1MJmb8x1JELomTn6
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/124
+
+Link to onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/58

--- a/cps/CP39.md
+++ b/cps/CP39.md
@@ -62,4 +62,5 @@ Everyone should be able to interact with Centrifuge and issuers using Centrifuge
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-evm-compatibility-for-centrifuge-chain-technical-proposal/5222
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmUfb51ovy7qjMnwX8DYoVF7c1Fg1pssVtsNXZovw4qiTP
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/129
+

--- a/cps/CP40.md
+++ b/cps/CP40.md
@@ -49,4 +49,6 @@ Minting requested tokens as rewards will help to support the overall goals and o
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-updating-tinlake-rewards-allocation-2023-03/5213
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmVsFJLpacuNFEgMuYzhZ3sZyVdmELvvqPsXQzgWqpwjHT
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/128
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/61

--- a/cps/CP45.md
+++ b/cps/CP45.md
@@ -44,4 +44,7 @@ The corresponding preimage hash is `0x6de31686f6a4fbf1584f91e45961862f44e5a692b2
 2. Referendum vote open for 50,400 blocks (~7 days)
 3. If referendum succeeds: Enactment after 57,600 blocks (~8 days)
 
-Link to the forum post: https://gov.centrifuge.io/t/cp45-ru-runtime-upgrade-1018-add-cfg-and-dot-to-asset-registry/5369
+Link to the RFC on the Forum: https://gov.centrifuge.io/t/cp45-ru-runtime-upgrade-1018-add-cfg-and-dot-to-asset-registry/5369
+
+Link to the onchain vote (democracy proposal + referendum): https://centrifuge.subsquare.io/democracy/proposals/1
+

--- a/cps/CP48.md
+++ b/cps/CP48.md
@@ -79,3 +79,5 @@ Stellaswap would be ready to launch this pool upon delivery of the tokens, or wh
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-cfg-liquidity-incentives-on-stellaswap-on-moonbeam/5356
 
 Link to the Opensquare Snapshot: https://voting.opensquare.io/p/135
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/66

--- a/cps/CP51.md
+++ b/cps/CP51.md
@@ -53,4 +53,6 @@ The corresponding preimage hash is `0x6de31686f6a4fbf1584f91e45961862f44e5a692b2
 1. Council Motion + fast-track
 2. Referendum vote open for 50,400 blocks (~7 days)
 
-Link to the forum post: https://gov.centrifuge.io/t/centrifuge-collator-selection-process-part-2/5457
+Link to the RFC on the Forum: https://gov.centrifuge.io/t/centrifuge-collator-selection-process-part-2/5457
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/65

--- a/cps/CP52.md
+++ b/cps/CP52.md
@@ -85,4 +85,5 @@ Full proposal on IPFS: https://pin.ski/3oNjQUI
 
 Link to RFC on the Forum: https://gov.centrifuge.io/t/rfc-changes-to-our-cp-framework-and-governance-process/5448
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmT3Jm89CLksmcPUCV4AMRWzTyYEQp9hBgsp7KxnCQcL5Y
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/138
+

--- a/cps/CP53.md
+++ b/cps/CP53.md
@@ -64,3 +64,5 @@ https://docs.hydradx.io/
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-listing-cfg-in-hydradx-omnipool-seeding-initial-liquidity/5412
 
 Link to the Opensquare Snapshot: https://voting.opensquare.io/p/139
+
+Link to the onchain vote (democracy proposal + referendum): https://centrifuge.subsquare.io/democracy/proposals/3

--- a/cps/CP54.md
+++ b/cps/CP54.md
@@ -55,3 +55,5 @@ The corresponding preimage hash is `0xb0c975c60b10c31574317a8174965721cc860d6f0c
 1. Council Motion 
 2. Referendum vote open for 50,400 blocks (~7 days)
 3. If referendum passes: Enactment after 57,600 blocks (~8 days)
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/67

--- a/cps/CP57.md
+++ b/cps/CP57.md
@@ -79,3 +79,7 @@ This will be a direct request from the treasury and the total supply will not be
 **Looking forward to any feedback and any concerns that you might have with this proposal.**
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-distribution-of-unpaid-collators-rewards/5566
+
+Link to the onchain vote (council motion + treasury proposal): https://centrifuge.subsquare.io/council/motions/69
+
+

--- a/cps/CP58.md
+++ b/cps/CP58.md
@@ -65,4 +65,4 @@ The Centrifuge DAO needs access to adequate funding to have the greatest chance 
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-treasury-spending-agreement/5575
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmXLTiaEnQqeZdTt1S9itqEbRNmfCB16ofoEZbDzgXRA1K
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/151

--- a/cps/CP59/CP59.md
+++ b/cps/CP59/CP59.md
@@ -99,6 +99,6 @@ Adaptability is part of the Centrifuge mission. It is beneficial for Centrifuge 
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-linked-pools-technical-proposal/5569
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/Qmd82VqAv8ogGGtW4FThB7r4BjrsqTma18pnzXtN1gd9Wd
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/152
 
 *Edit note: This RFC is an updated version of [RFC 5453](https://gov.centrifuge.io/t/rfc-linked-pools-technical-proposal/5453) with clearer language. 5453 has been closed in favor of this rfc.*

--- a/cps/CP6.md
+++ b/cps/CP6.md
@@ -79,4 +79,4 @@ With a funded Treasury, any individual or group following CP Framework could off
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-add-a-block-reward-and-improve-collators-cycle/4766
 
-Link to the Opensquare Snapshot: https://voting.opensquare.io/space/centrifuge/proposal/QmYh1uJmu4VgEa6H5CSirZ9juJTdbTAB77LazAK4tB9Gpv
+Link to the Opensquare Snapshot: https://voting.opensquare.io/p/102

--- a/cps/CP61.md
+++ b/cps/CP61.md
@@ -92,4 +92,5 @@ The goal of this rewards proposal is to balance an incentive for users of Centri
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-pool-rewards-parameters/5643
 
-Link to on-chain referendum: https://centrifuge.subsquare.io/democracy/referenda/39
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/70
+

--- a/cps/CP64.md
+++ b/cps/CP64.md
@@ -42,3 +42,5 @@ The corresponding preimage hash is `0xb4630b6a8da269253100ea1c24317fa566c7eb09e1
 1. Council Motion + fast-track
 2. Referendum vote open for 3,600 blocks (~12 hours)
 3. If the referendum passes: the enactment will be immediately after
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/72

--- a/cps/CP66/CP66.md
+++ b/cps/CP66/CP66.md
@@ -119,5 +119,6 @@ status: passed
   * Expected lending rate to end borrower (off-chain): n/a
 
 
- Link to the POP on the Forum: https://gov.centrifuge.io/t/pop-anemoy-liquid-treasury-fund-1/5651
- Link to the on-chain voting: https://centrifuge.subsquare.io/democracy/referenda/41
+Link to the RFC (POP) on the Forum: https://gov.centrifuge.io/t/pop-anemoy-liquid-treasury-fund-1/5651
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/74

--- a/cps/CP73.md
+++ b/cps/CP73.md
@@ -61,3 +61,5 @@ Summary generated with srtool v0.9.25 using the docker image paritytech/srtool:1
 1. Council Motion + fast-track
 2. Referendum vote open for 21,600 blocks (~3 days)
 3. If the referendum passes: the enactment will be immediately after
+
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/75

--- a/cps/CP76.md
+++ b/cps/CP76.md
@@ -25,4 +25,5 @@ Pre-image: `0x4b4af7b042a143b85b86c775d509e69442be0e74d35ab4db778e15097d306e07`
 2. Referendum vote open for 14,400 blocks (~2 days)
 3. If the referendum passes: the enactment will be immediately after
 
-Link to on-chain referendum: https://centrifuge.subsquare.io/democracy/referenda/43
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/76
+

--- a/cps/CP78.md
+++ b/cps/CP78.md
@@ -147,4 +147,4 @@ Since the latest srtool does not produce a WASM report due to this issue, the fo
 
 Link to the RFC on the Forum: https://gov.centrifuge.io/t/cp78-runtime-upgrade-1024/5876
 
-Link to the Subsquare voting: https://centrifuge.subsquare.io/democracy/referenda/44
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/77

--- a/cps/CP80.md
+++ b/cps/CP80.md
@@ -32,6 +32,6 @@ Pre-image: `0xe39871b21dc08b74bffac18610e63fa1176d1bde1d4786cdf1a9b7ee38f28bad`
 3. If the referendum passes: the enactment will be immediately after
 
 
-Link to the Forum: https://gov.centrifuge.io/t/cp80-registering-frax-token-and-allowing-trading-frax-usdc/5910
+Link to the RFC on the Forum: https://gov.centrifuge.io/t/cp80-registering-frax-token-and-allowing-trading-frax-usdc/5910
 
-Link to on-chain referendum: https://centrifuge.subscan.io/referenda/46
+Link to the onchain vote (council motion + referendum): https://centrifuge.subsquare.io/council/motions/80

--- a/cps/CP81.md
+++ b/cps/CP81.md
@@ -46,6 +46,6 @@ These transferred CFG tokens could be used for the benefit of protocol improveme
 
 ------------------
 
-Link to the Forum: https://gov.centrifuge.io/t/rfc-unclaimed-tinlake-rewards/5885
+Link to the RFC on the Forum: https://gov.centrifuge.io/t/rfc-unclaimed-tinlake-rewards/5885
 
 Link to the Opensquare Snapshot: https://voting.opensquare.io/p/175

--- a/cps/CP87.md
+++ b/cps/CP87.md
@@ -6,8 +6,8 @@ proposal-type: Non-Technical
 author(s): Jeroen
 contributor(s): Kate_Bee 
 date proposed: 2023-12-20
-date-ended: 
-status: polling
+date-ended: 2023-03-07
+status: Passed
 replaces previous roadmap: N/A
 ---
 


### PR DESCRIPTION
The following changes have been made to CPs:

- Replacing OpenSquare Snapshot links with short version of the links
- Adding link to council motion/referendum on SubSquare where relevant
- Adjusting the description of the links to keep them consistent and make them more accurate
   - clarify whether they are linking to a council motion/democracy proposal/treasury proposal