### PR TITLE
Create Twitter Using Micro-Influencer Marketing

### DIFF
--- a/cps/CP2/Proposal to Enhance Centrifuge’s Growth on X/Twitter Using Micro-Influencer Marketing
+++ b/cps/CP2/Proposal to Enhance Centrifuge’s Growth on X/Twitter Using Micro-Influencer Marketing
@@ -1,0 +1,114 @@
+Introduction
+
+Centrifuge is an innovative project with significant potential, but its growth on X/Twitter has been limited. A strong presence on X is crucial to attracting investors, expanding the community, and increasing engagement. This proposal presents a strategic solution to boost Centrifuge’s visibility and engagement through micro-influencer marketing.
+
+Problem Statement
+
+Despite its value proposition, Centrifuge is not fully utilizing X/Twitter to:
+
+Reach its target audience effectively.
+
+Engage with potential investors.
+
+Build a strong and interactive community.
+
+Capitalize on the platform’s potential for organic growth and virality.
+
+Solution: Leveraging Micro-Influencers
+
+Micro-influencers have the power to create buzz, attract new users, and improve engagement through consistent, targeted messaging.
+
+Our Strategy
+
+We propose a structured campaign where our team of micro-influencers will:
+
+Create High-Quality Daily Content – Posting 150+ tweets and interactions monthly to keep Centrifuge visible.
+
+Engage With the Community – Replying to relevant conversations to drive organic discussions.
+
+Boost Centrifuge’s Algorithmic Reach – Through consistent likes, retweets, and quote tweets.
+
+Leverage Key Opinion Leaders (KOLs) – Collaborating with trusted influencers to enhance credibility.
+
+Integrate With Telegram & Discord – Extending engagement beyond X/Twitter.
+
+Proposed Packages
+
+Based on DecentralizedHub’s experience and proven track record, we offer tailored packages:
+
+Silver Package - $1,500
+
+150 tweets/month
+
+200+ replies to relevant influencers
+
+Engagement (likes & retweets) on all Centrifuge tweets
+
+Gold Package - $2,000
+
+200 tweets/month
+
+300+ replies to relevant influencers
+
+Quote retweets from influencers
+
+1 Micro-KOL included
+
+Premium Package - $2,500
+
+250 tweets/month
+
+400+ replies to relevant influencers
+
+Telegram & Discord promotions
+
+2 Micro-KOLs included
+
+Premium Plus Package - $6,000
+
+250+ tweets & threads
+
+Flexibility to push specific updates
+
+Influencer engagement on recent developments
+
+3 Micro-KOLs included
+
+Guerilla Marketing - $10,000
+
+Fully customized campaign to dominate X/Twitter and maximize reach
+
+All prices are negotiable with 50% upfront payment required.
+
+Experience & Proof of Work
+
+We have successfully driven engagement for projects like Defactor, DTravel, IMO, and iGames. Our results speak for themselves:
+
+Defactor Campaign: Proof
+
+DTravel Metrics: Proof
+
+IMO & iGames: Proof
+
+Defactor Growth Metrics (Nov 19 - Dec 19, 2024):
+
+Mentions: 591
+
+Social Media Reach: 3.1M
+
+Interactions: 9447
+
+User-Generated Content: 557
+
+Likes: 6915
+
+AVE: $279K
+
+Full Report Available
+https://drive.google.com/file/d/1FoS5fN5e3BiGlOh6PPcNcPSFcruxybGI/view?usp=drive_link
+
+Conclusion
+
+This proposal outlines a proven strategy to elevate Centrifuge’s presence on X/Twitter, ensuring sustainable growth and enhanced visibility. With our micro-influencer network, Centrifuge can attract more investors, engage effectively, and build a thriving community.
+
+We look forward to collaborating with Centrifuge DAO to implement this strategy and drive meaningful impact.


### PR DESCRIPTION
Our proposed strategy aims to bridge the gap between Centrifuge and its target audience by leveraging micro-influencers who have built credibility and engagement within the crypto space. Unlike traditional marketing, which can be costly and inefficient, micro-influencer marketing ensures authentic interactions and organic reach, leading to higher conversion rates.

By employing a mix of consistent content creation, community engagement, and algorithmic boosting, we can position Centrifuge as a dominant player on X/Twitter. Our strategy doesn’t just focus on visibility but also on nurturing relationships with potential investors and users to sustain long-term growth.

Additionally, our experience working with top-tier crypto projects like Defactor and DTravel provides concrete proof that our approach delivers tangible results. We are confident that our micro-influencer-driven campaigns will not only expand Centrifuge’s social media presence but also solidify its credibility and impact within the crypto ecosystem.